### PR TITLE
formatting

### DIFF
--- a/OOM-error-variables.tf
+++ b/OOM-error-variables.tf
@@ -46,7 +46,14 @@ variable "oom_error_alerting_enabled" {
   default = true
 }
 
-variable "type" {
+variable "oom_error_type" {
   type    = string
   default = "log alert"
+}
+
+variable "oom_error_priority" {
+  description = "Number from 1 (high) to 5 (low)."
+
+  type    = number
+  default = null
 }

--- a/OOM-error.tf
+++ b/OOM-error.tf
@@ -8,32 +8,29 @@ locals {
 module "oom_error" {
   source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.5"
 
-  name  = "Out Of Memory errors in the logs"
-  query = "logs(\"OOM command not allowed when used memory \\> 'maxmemory'.\").index(\"*\").rollup(\"count\").last(\"15m\") > ${var.oom_error_critical}"
-
-  enabled          = var.oom_error_enabled
-  alerting_enabled = var.oom_error_alerting_enabled
-
+  name             = "Out Of Memory errors in the logs"
+  query            = "logs(\"OOM command not allowed when used memory \\> 'maxmemory'.\").index(\"*\").rollup(\"count\").last(\"15m\") > ${var.oom_error_critical}"
   alert_message    = <<EOF
 Available memory on ${var.service} has dropped so much we are getting OOM errors in the logging.
 See: https://app.datadoghq.eu/logs?query=OOM%20command%20not%20allowed%20when%20used%20memory%20%3E%20%27maxmemory%27.&index=%2A&integration_id=&integration_short_name=&saved_view=19730&from_ts=1617618461039&to_ts=1617704861039&live=true&cols=host%2Cservice&stream_sort=service%2Cdesc&messageDisplay=inline&viz=stream
     EOF
   recovery_message = "No more OOM error log entries in the last 15 minutes."
+  type             = var.oom_error_type
 
-  service         = var.service
-  env             = var.alert_env
-  severity        = var.oom_error_severity
-  note            = var.oom_error_note
-  docs            = var.oom_error_docs
-  additional_tags = var.additional_tags
-
-  notification_channel = var.notification_channel
-
-  require_full_window = true
-  locked              = var.locked
-
-  type = var.type
-
+  # monitor level vars
+  enabled            = var.oom_error_enabled
+  alerting_enabled   = var.oom_error_alerting_enabled
   critical_threshold = var.oom_error_critical
   warning_threshold  = var.oom_error_warning
+  priority           = var.oom_error_priority
+  severity           = var.oom_error_severity
+  docs               = var.oom_error_docs
+  note               = var.oom_error_note
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
 }

--- a/blocked-clients-variables.tf
+++ b/blocked-clients-variables.tf
@@ -45,3 +45,10 @@ variable "blocked_clients_alerting_enabled" {
   type    = bool
   default = true
 }
+
+variable "blocked_clients_priority" {
+  description = "Number from 1 (high) to 5 (low)."
+
+  type    = number
+  default = null
+}

--- a/blocked-clients.tf
+++ b/blocked-clients.tf
@@ -8,27 +8,25 @@ locals {
 module "blocked_clients_clients" {
   source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.5"
 
-  name  = "Blocked Clients"
-  query = "avg(${var.blocked_clients_evaluation_period}):avg:redis.clients.blocked{${local.blocked_clients_filter}} >= ${var.blocked_clients_critical}"
-
-  enabled          = var.blocked_clients_enabled
-  alerting_enabled = var.blocked_clients_alerting_enabled
-
+  name             = "Blocked Clients"
+  query            = "avg(${var.blocked_clients_evaluation_period}):avg:redis.clients.blocked{${local.blocked_clients_filter}} >= ${var.blocked_clients_critical}"
   alert_message    = "${var.service} is waiting to fill a request with data. Until the data is filled, the client is blocked. Current threshold: {{threshold}} and is currently at {{value}} blocked clients. This could indicate a latency issue or timeouts upstream."
   recovery_message = "${var.service} blocked clients is back to {{value}}"
 
-  service         = var.service
-  env             = var.alert_env
-  severity        = var.blocked_clients_severity
-  note            = var.blocked_clients_note
-  docs            = var.blocked_clients_docs
-  additional_tags = var.additional_tags
-
-  notification_channel = var.notification_channel
-
-  require_full_window = true
-  locked              = var.locked
-
+  # monitor level vars
+  enabled            = var.blocked_clients_enabled
+  alerting_enabled   = var.blocked_clients_alerting_enabled
   critical_threshold = var.blocked_clients_critical
   warning_threshold  = var.blocked_clients_warning
+  priority           = var.blocked_clients_priority
+  severity           = var.blocked_clients_severity
+  docs               = var.blocked_clients_docs
+  note               = var.blocked_clients_note
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
 }

--- a/connected-client.tf
+++ b/connected-client.tf
@@ -8,27 +8,25 @@ locals {
 module "connected_clients" {
   source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.5"
 
-  name  = "Connected Clients"
-  query = "avg(${var.connected_clients_evaluation_period}):avg:redis.net.clients{${local.connected_clients_filter}} >= ${var.connected_clients_critical}"
-
-  enabled          = var.connected_clients_enabled
-  alerting_enabled = var.connected_clients_alerting_enabled
-
+  name             = "Connected Clients"
+  query            = "avg(${var.connected_clients_evaluation_period}):avg:redis.net.clients{${local.connected_clients_filter}} >= ${var.connected_clients_critical}"
   alert_message    = "Amount of connected clients to ${var.service} has gone above {{threshold}} and is currently {{value}}%. This could indicate problems with upstream not responding quickly enough."
   recovery_message = "Amount of connected clients to ${var.service} has recovered to {{value}}"
 
-  service         = var.service
-  env             = var.alert_env
-  severity        = var.connected_clients_severity
-  note            = var.connected_clients_note
-  docs            = var.connected_clients_docs
-  additional_tags = var.additional_tags
-
-  notification_channel = var.notification_channel
-
-  require_full_window = true
-  locked              = var.locked
-
+  # monitor level vars
+  enabled            = var.connected_clients_enabled
+  alerting_enabled   = var.connected_clients_alerting_enabled
   critical_threshold = var.connected_clients_critical
   warning_threshold  = var.connected_clients_warning
+  priority           = var.connected_clients_priority
+  severity           = var.connected_clients_severity
+  docs               = var.connected_clients_docs
+  note               = var.connected_clients_note
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
 }

--- a/connected-clients-variables.tf
+++ b/connected-clients-variables.tf
@@ -45,3 +45,10 @@ variable "connected_clients_alerting_enabled" {
   type    = bool
   default = true
 }
+
+variable "connected_clients_priority" {
+  description = "Number from 1 (high) to 5 (low)."
+
+  type    = number
+  default = null
+}

--- a/evicted-keys-variables.tf
+++ b/evicted-keys-variables.tf
@@ -45,3 +45,10 @@ variable "evicted_keys_alerting_enabled" {
   type    = bool
   default = true
 }
+
+variable "evicted_keys_priority" {
+  description = "Number from 1 (high) to 5 (low)."
+
+  type    = number
+  default = null
+}

--- a/evicted-keys.tf
+++ b/evicted-keys.tf
@@ -8,27 +8,25 @@ locals {
 module "evicted_keys" {
   source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.5"
 
-  name  = "Evicted Keys"
-  query = "avg(${var.evicted_keys_evaluation_period}):avg:redis.keys.evicted{${local.evicted_keys_filter}} >= ${var.evicted_keys_critical}"
-
-  enabled          = var.evicted_keys_enabled
-  alerting_enabled = var.evicted_keys_alerting_enabled
-
+  name             = "Evicted Keys"
+  query            = "avg(${var.evicted_keys_evaluation_period}):avg:redis.keys.evicted{${local.evicted_keys_filter}} >= ${var.evicted_keys_critical}"
   alert_message    = "Memory usage on ${var.service} has gone so high, it needs to start evicting keys. Current threshold: {{threshold}} and is eviction rate: {{value}}"
   recovery_message = "${var.service} is evicting keys at the rate of  {{value}}"
 
-  service         = var.service
-  env             = var.alert_env
-  severity        = var.evicted_keys_severity
-  note            = var.evicted_keys_note
-  docs            = var.evicted_keys_docs
-  additional_tags = var.additional_tags
-
-  notification_channel = var.notification_channel
-
-  require_full_window = true
-  locked              = var.locked
-
+  # monitor level vars
+  enabled            = var.evicted_keys_enabled
+  alerting_enabled   = var.evicted_keys_alerting_enabled
   critical_threshold = var.evicted_keys_critical
   warning_threshold  = var.evicted_keys_warning
+  priority           = var.evicted_keys_priority
+  severity           = var.evicted_keys_severity
+  note               = var.evicted_keys_note
+  docs               = var.evicted_keys_docs
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
 }

--- a/hitratio-variables.tf
+++ b/hitratio-variables.tf
@@ -45,3 +45,10 @@ variable "hitratio_alerting_enabled" {
   type    = bool
   default = true
 }
+
+variable "hitratio_priority" {
+  description = "Number from 1 (high) to 5 (low)."
+
+  type    = number
+  default = null
+}

--- a/hitratio.tf
+++ b/hitratio.tf
@@ -8,28 +8,25 @@ locals {
 module "hitratio" {
   source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.5"
 
-  name  = "Hitratio"
-  query = "avg(${var.hitratio_evaluation_period}):( avg:redis.stats.keyspace_hits{${local.hitratio_filter}} / ( avg:redis.stats.keyspace_hits{${local.hitratio_filter}} + avg:redis.stats.keyspace_misses{${local.hitratio_filter}} ) ) * 100 <= ${var.hitratio_critical}"
-
-  enabled          = var.hitratio_enabled
-  alerting_enabled = var.hitratio_alerting_enabled
-
-
+  name             = "Hitratio"
+  query            = "avg(${var.hitratio_evaluation_period}):( avg:redis.stats.keyspace_hits{${local.hitratio_filter}} / ( avg:redis.stats.keyspace_hits{${local.hitratio_filter}} + avg:redis.stats.keyspace_misses{${local.hitratio_filter}} ) ) * 100 <= ${var.hitratio_critical}"
   alert_message    = "Hit Ratio on ${var.service} has dropped below {{threshold}}% and is {{value}}%."
   recovery_message = "Hit Ratio on ${var.service} has recovered to {{value}}%"
 
-  service         = var.service
-  env             = var.alert_env
-  severity        = var.hitratio_severity
-  note            = var.hitratio_note
-  docs            = var.hitratio_docs
-  additional_tags = var.additional_tags
-
-  notification_channel = var.notification_channel
-
-  require_full_window = true
-  locked              = var.locked
-
+  # monitor level vars
+  enabled            = var.hitratio_enabled
+  alerting_enabled   = var.hitratio_alerting_enabled
   critical_threshold = var.hitratio_critical
   warning_threshold  = var.hitratio_warning
+  priority           = var.hitratio_priority
+  severity           = var.hitratio_severity
+  docs               = var.hitratio_docs
+  note               = var.hitratio_note
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
 }

--- a/latency-variables.tf
+++ b/latency-variables.tf
@@ -45,3 +45,10 @@ variable "latency_alerting_enabled" {
   type    = bool
   default = true
 }
+
+variable "latency_priority" {
+  description = "Number from 1 (high) to 5 (low)."
+
+  type    = number
+  default = null
+}

--- a/latency.tf
+++ b/latency.tf
@@ -8,27 +8,25 @@ locals {
 module "latency" {
   source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.5"
 
-  name  = "Latency"
-  query = "avg(${var.latency_evaluation_period}):avg:redis.info.latency_ms{${local.latency_filter}} >= ${var.latency_critical}"
-
-  enabled          = var.latency_enabled
-  alerting_enabled = var.latency_alerting_enabled
-
+  name             = "Latency"
+  query            = "avg(${var.latency_evaluation_period}):avg:redis.info.latency_ms{${local.latency_filter}} >= ${var.latency_critical}"
   alert_message    = "Latency on ${var.service} has dropped below {{threshold}} and has {{value}} available"
   recovery_message = "Latency on ${var.service} has recovered {{value}}"
 
-  service         = var.service
-  env             = var.alert_env
-  severity        = var.latency_severity
-  note            = var.latency_note
-  docs            = var.latency_docs
-  additional_tags = var.additional_tags
-
-  notification_channel = var.notification_channel
-
-  require_full_window = true
-  locked              = var.locked
-
+  # monitor level vars
+  enabled            = var.latency_enabled
+  alerting_enabled   = var.latency_alerting_enabled
   critical_threshold = var.latency_critical
   warning_threshold  = var.latency_warning
+  priority           = var.latency_priority
+  severity           = var.latency_severity
+  docs               = var.latency_docs
+  note               = var.latency_note
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
 }

--- a/memory-fragmentation-variables.tf
+++ b/memory-fragmentation-variables.tf
@@ -45,3 +45,10 @@ variable "memory_fragmentation_alerting_enabled" {
   type    = bool
   default = true
 }
+
+variable "memory_fragmentation_priority" {
+  description = "Number from 1 (high) to 5 (low)."
+
+  type    = number
+  default = null
+}

--- a/memory-fragmentation.tf
+++ b/memory-fragmentation.tf
@@ -8,29 +8,25 @@ locals {
 module "memory_fragmentation" {
   source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.5"
 
-  name  = "Memory Fragmentation"
-  query = "avg(${var.memory_fragmentation_evaluation_period}):avg:redis.mem.fragmentation_ratio{${local.memory_fragmentation_filter}} > ${var.memory_fragmentation_critical}"
-
-  enabled          = var.memory_fragmentation_enabled
-  alerting_enabled = var.memory_fragmentation_alerting_enabled
-
-
+  name             = "Memory Fragmentation"
+  query            = "avg(${var.memory_fragmentation_evaluation_period}):avg:redis.mem.fragmentation_ratio{${local.memory_fragmentation_filter}} > ${var.memory_fragmentation_critical}"
   alert_message    = "Memory Fragmentation problem on ${var.service}. Meaning the OS cannot supply ${var.service} with 'single blocks' of memory. So it has to fragment ${var.service}'s memory in order to still fit.  The threshold for this alert is {{threshold}} and the fragmentation is currently {{value}}."
   recovery_message = "Memory Fragmentation on ${var.service} has recovered to {{value}} single block of memory."
 
-
-  service         = var.service
-  env             = var.alert_env
-  severity        = var.memory_fragmentation_severity
-  note            = var.memory_fragmentation_note
-  docs            = var.memory_fragmentation_docs
-  additional_tags = var.additional_tags
-
-  notification_channel = var.notification_channel
-
-  require_full_window = true
-  locked              = var.locked
-
+  # monitor level vars
+  enabled            = var.memory_fragmentation_enabled
+  alerting_enabled   = var.memory_fragmentation_alerting_enabled
   critical_threshold = var.memory_fragmentation_critical
   warning_threshold  = var.memory_fragmentation_warning
+  priority           = var.memory_fragmentation_priority
+  severity           = var.memory_fragmentation_severity
+  docs               = var.memory_fragmentation_docs
+  note               = var.memory_fragmentation_note
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
 }

--- a/memory-free-bytes-variables.tf
+++ b/memory-free-bytes-variables.tf
@@ -45,3 +45,10 @@ variable "memory_free_bytes_alerting_enabled" {
   type    = bool
   default = true
 }
+
+variable "memory_free_bytes_priority" {
+  description = "Number from 1 (high) to 5 (low)."
+
+  type    = number
+  default = null
+}

--- a/memory-free-bytes.tf
+++ b/memory-free-bytes.tf
@@ -8,27 +8,25 @@ locals {
 module "memory_free_bytes" {
   source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.5"
 
-  name  = "Available Memory"
-  query = "avg(${var.memory_free_bytes_evaluation_period}):avg:redis.mem.maxmemory{${local.memory_free_bytes_filter}} - avg:redis.mem.used{${local.memory_free_bytes_filter}} < ${var.memory_free_bytes_critical}"
-
-  enabled          = var.memory_free_bytes_enabled
-  alerting_enabled = var.memory_free_bytes_alerting_enabled
-
+  name             = "Available Memory"
+  query            = "avg(${var.memory_free_bytes_evaluation_period}):avg:redis.mem.maxmemory{${local.memory_free_bytes_filter}} - avg:redis.mem.used{${local.memory_free_bytes_filter}} < ${var.memory_free_bytes_critical}"
   alert_message    = "Available memory on ${var.service} has dropped below {{threshold}} and has {{value}} available"
   recovery_message = "Available memory on ${var.service} has recovered {{value}}"
 
-  service         = var.service
-  env             = var.alert_env
-  severity        = var.memory_free_bytes_severity
-  note            = var.memory_free_bytes_note
-  docs            = var.memory_free_bytes_docs
-  additional_tags = var.additional_tags
-
-  notification_channel = var.notification_channel
-
-  require_full_window = true
-  locked              = var.locked
-
+  # monitor level vars
+  enabled            = var.memory_free_bytes_enabled
+  alerting_enabled   = var.memory_free_bytes_alerting_enabled
   critical_threshold = var.memory_free_bytes_critical
   warning_threshold  = var.memory_free_bytes_warning
+  priority           = var.memory_free_bytes_priority
+  severity           = var.memory_free_bytes_severity
+  docs               = var.memory_free_bytes_docs
+  note               = var.memory_free_bytes_note
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
 }

--- a/memory-used-percentage-variables.tf
+++ b/memory-used-percentage-variables.tf
@@ -45,3 +45,10 @@ variable "memory_used_percentage_alerting_enabled" {
   type    = bool
   default = true
 }
+
+variable "memory_used_percentage_priority" {
+  description = "Number from 1 (high) to 5 (low)."
+
+  type    = number
+  default = null
+}

--- a/memory-used-percentage.tf
+++ b/memory-used-percentage.tf
@@ -8,28 +8,25 @@ locals {
 module "memory_used_percentage" {
   source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.5"
 
-  name  = "Memory Usage"
-  query = "avg(${var.memory_used_percentage_evaluation_period}):( avg:redis.mem.used{${local.memory_used_percentage_filter}} / avg:redis.mem.maxmemory{${local.memory_used_percentage_filter}} ) * 100 >= ${var.memory_used_percentage_critical}"
-
-  enabled          = var.memory_used_percentage_enabled
-  alerting_enabled = var.memory_used_percentage_alerting_enabled
-
-
+  name             = "Memory Usage"
+  query            = "avg(${var.memory_used_percentage_evaluation_period}):( avg:redis.mem.used{${local.memory_used_percentage_filter}} / avg:redis.mem.maxmemory{${local.memory_used_percentage_filter}} ) * 100 >= ${var.memory_used_percentage_critical}"
   alert_message    = "Memory usage on ${var.service} has gone above {{threshold}}% and is currently {{value}}%."
   recovery_message = "Memory usage on ${var.service} has recovered to {{value}}%"
 
-  service         = var.service
-  env             = var.alert_env
-  severity        = var.memory_used_percentage_severity
-  note            = var.memory_used_percentage_note
-  docs            = var.memory_used_percentage_docs
-  additional_tags = var.additional_tags
-
-  notification_channel = var.notification_channel
-
-  require_full_window = true
-  locked              = var.locked
-
+  # monitor level vars
+  enabled            = var.memory_used_percentage_enabled
+  alerting_enabled   = var.memory_used_percentage_alerting_enabled
   critical_threshold = var.memory_used_percentage_critical
   warning_threshold  = var.memory_used_percentage_warning
+  priority           = var.memory_used_percentage_priority
+  severity           = var.memory_used_percentage_severity
+  docs               = var.memory_used_percentage_docs
+  note               = var.memory_used_percentage_note
+
+  # module level vars
+  env                  = var.alert_env
+  service              = var.service
+  notification_channel = var.notification_channel
+  additional_tags      = var.additional_tags
+  locked               = var.locked
 }


### PR DESCRIPTION
Recently discussed with @rhynix that we wanted to restructure / group the parameters

The goal is to put the most important and chaged values at the top and the values that don't change to often are on the bottom

Example:
```terraform
module "connected_clients" {
  source = "git@github.com:kabisa/terraform-datadog-generic-monitor.git?ref=0.5"

  name             = "Connected Clients"
  query            = "avg(${var.connected_clients_evaluation_period}):avg:redis.net.clients{${local.connected_clients_filter}} >= ${var.connected_clients_critical}"
  alert_message    = "Amount of connected clients to ${var.service} has gone above {{threshold}} and is currently {{value}}%. This could indicate problems with upstream not responding quickly enough."
  recovery_message = "Amount of connected clients to ${var.service} has recovered to {{value}}"

  # monitor level vars
  enabled            = var.connected_clients_enabled
  alerting_enabled   = var.connected_clients_alerting_enabled
  critical_threshold = var.connected_clients_critical
  warning_threshold  = var.connected_clients_warning
  priority           = var.connected_clients_priority
  severity           = var.connected_clients_severity
  docs               = var.connected_clients_docs
  note               = var.connected_clients_note

  # module level vars
  env                  = var.alert_env
  service              = var.service
  notification_channel = var.notification_channel
  additional_tags      = var.additional_tags
  locked               = var.locked
}
```